### PR TITLE
Updates regex to support git <1.9.1

### DIFF
--- a/src/lib/GitCommands.coffee
+++ b/src/lib/GitCommands.coffee
@@ -9,7 +9,7 @@ ChildProcess = require('child_process')
 env = process.env
 env.GIT_MERGE_AUTOEDIT = 'no'
 
-GIT_CLEAN_REGEX = /^nothing to commit, working directory clean$/m
+GIT_CLEAN_REGEX = /^nothing to commit,? \(?working directory clean\)?$/m
 
 class GitCommands
   @checkForCleanWorkingDirectory: ->


### PR DESCRIPTION
git status output for a clean repo changed from `nothing to commit (working directory clean)` to `nothing to commit, working directory clean` sometime between 1.7.1 and 1.9.1.  This PR updates the regex to support those of us stuck with older versions of git.