### PR TITLE
Support with git 2.9.x

### DIFF
--- a/src/lib/GitCommands.coffee
+++ b/src/lib/GitCommands.coffee
@@ -11,7 +11,7 @@ Temp = require 'temp'
 env = process.env
 env.GIT_MERGE_AUTOEDIT = 'no'
 
-GIT_CLEAN_REGEX = /^nothing to commit,? \(?working directory clean\)?$/m
+GIT_CLEAN_REGEX = /^nothing to commit,? \(?working (directory|tree) clean\)?$/m
 AVH_EDITION_REGEX = /AVH Edition/
 
 class GitCommands


### PR DESCRIPTION
After upgrade to git 2.9.1 `generate-release` throws `"Working directory is not clean, not ready for release"` error even when directory is currently clean.

After debugging I found that description about directory status was changed (`git status`).
Previously:
```
On branch develop
Your branch is up-to-date with 'origin/develop'.
nothing to commit, working directory clean
```
Now:
```
On branch develop
Your branch is up-to-date with 'origin/develop'.
nothing to commit, working tree clean
```

Word `directory` was changed into `tree`.